### PR TITLE
pa-scheduler-kue-rediscluster to 0.0.6

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -15,4 +15,4 @@ dependencies:
   version: 0.0.1
 - name: pa-scheduler-kue-rediscluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.5
+  version: 0.0.6


### PR DESCRIPTION
Promote pa-scheduler-kue-rediscluster to version 0.0.6